### PR TITLE
Support connecting to channels with channel keywords without NickServ

### DIFF
--- a/bot/transports/irc.js
+++ b/bot/transports/irc.js
@@ -10,7 +10,15 @@ var IRC = module.exports = function (bot, name, config) {
     Transport.call(this, bot, name);
     var transport = this;
 
-    this.irc = new irc.Client(config.host, config.nick, config.opts);
+    var client = this.irc = new irc.Client(config.host, config.nick, config.opts);
+
+    // Connect to channels manually after receiving MOTD.
+    this.irc.on('motd', function () {
+        (config.channels || []).forEach(function (channel) {
+            var keyword = config.channel_keywords && config.channel_keywords[channel];
+            client.join(channel + (keyword ? ' ' + keyword : ''));
+        });
+    });
 
     // Set up some log events.
     this.irc.conn.on('connect', function () {

--- a/config.sample.json
+++ b/config.sample.json
@@ -23,7 +23,12 @@
                 "selfSigned": true,
                 "userName": "borgil",
                 "realName": "Borgil of Menelvagor"
-            }
+            },
+        "channels": [
+            "#some-example-channel-name"
+        ],
+        "channel_keywords": {
+            "#some-example-channel-name": "channelkeyword"
         },
         "i2p": {
             "type": "irc",

--- a/config.sample.yml
+++ b/config.sample.yml
@@ -20,6 +20,10 @@ transports:
             selfSigned: true
             userName: borgil
             realName: Borgil of Menelvagor
+        channels:
+            - '#some-example-channel-name'
+        channel_keywords:
+            '#some-example-channel-name': channelkeyword
     i2p:
         type: irc
         host: localhost


### PR DESCRIPTION
These config values must be in the base IRC network config, not in "opts".
Updated sample config.